### PR TITLE
MID-2409 Creating a new ClusterRole and ClusterRoleBinding

### DIFF
--- a/deploy/operator/apply/02_MetacontrollerClusterRoles.yaml
+++ b/deploy/operator/apply/02_MetacontrollerClusterRoles.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gateway-operator
+rules:
+  - apiGroups:
+      - zalando.org
+    resources:
+      - fabricgateways
+      - fabricgateways/status
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gateway-operator
+subjects:
+  - kind: ServiceAccount
+    name: fabric
+    namespace: fabric
+roleRef:
+  kind: ClusterRole
+  name: gateway-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/operator/apply/04_ClusterRole.yaml
+++ b/deploy/operator/apply/04_ClusterRole.yaml
@@ -6,6 +6,6 @@ rules:
   - apiGroups:
       - zalando.org
     resources:
-      - stackset
+      - stacksets
     verbs:
       - get


### PR DESCRIPTION
Binds the required FabricGateway roles back into the metacontroller service account fabric in namespace fabric.