### PR TITLE
MID-2441: Add token id to access log

### DIFF
--- a/deploy/operator/apply/06_ClusterRoleBinding.yaml
+++ b/deploy/operator/apply/06_ClusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: fabric-gateway-k8s-api-access
+  name: "{{{ COMPOSITE_CONTROLLER_NAME }}}"
 subjects:
   - kind: ServiceAccount
     name: "{{{ COMPOSITE_CONTROLLER_NAME }}}"

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -181,8 +181,12 @@ object SynchDomain {
       """inlineContent("{\"title\":\"Gateway Rejected\",\"status\":403,\"detail\":\"Illegal attempt to access whitelisted route\"}")"""
   }
 
-  case object AdminAuditing extends SkipperFilter {
-    val skipperStringValue: String = """unverifiedAuditLog("https://identity.zalando.com/managed-id")"""
+  object AccessLogAuditing {
+    val UserRealmTokenIdentifierKey = "https://identity.zalando.com/managed-id"
+    val ServiceRealmTokenIdentifierKey = "sub"
+  }
+  case class AccessLogAuditing(key: String = AccessLogAuditing.UserRealmTokenIdentifierKey) extends SkipperFilter {
+    val skipperStringValue: String = s"""unverifiedAuditLog("$key")"""
   }
 
   sealed trait RateLimitPeriod {

--- a/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
@@ -55,12 +55,21 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
         Nil,
         Some(
           SkipperCustomRoute(NEL.one(PathSubTreeMatch("/")),
-                             NEL.of(RequiredPrivileges(NEL.one("uid")), Status(404), DefaultRejectMsg, Shunt)))
+                             NEL.of(
+                               RequiredPrivileges(NEL.one("uid")),
+                               AccessLogAuditing(AccessLogAuditing.ServiceRealmTokenIdentifierKey),
+                               Status(404),
+                               DefaultRejectMsg, Shunt
+                             )
+          ))
       ) :: SkipperRouteDefinition(
         meta.name.concat(DnsString.DefaultHttpRejectRouteSuffix),
         Nil,
         Nil,
-        Some(SkipperCustomRoute(NEL.of(PathSubTreeMatch("/"), HttpTraffic), NEL.of(Status(400), HttpRejectMsg, Shunt)))
+        Some(SkipperCustomRoute(
+          NEL.of(PathSubTreeMatch("/"), HttpTraffic),
+          NEL.of(AccessLogAuditing(AccessLogAuditing.ServiceRealmTokenIdentifierKey), Status(400), HttpRejectMsg, Shunt))
+        )
       ) :: Nil
 
     val routeDerivationOutput: Future[List[SkipperRouteDefinition]] = Source

--- a/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
@@ -225,7 +225,7 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
 
     routes.size should not be 0
     routes.forall(_.metadata.routeDefinition.filters.contains(EnableAccessLog(List(2, 4, 5)))) shouldBe true
-    routes.forall(_.metadata.routeDefinition.filters.contains(AccessLogAuditing("blah"))) shouldBe true
+    routes.forall(_.metadata.routeDefinition.filters.contains(AccessLogAuditing("https://identity.zalando.com/managed-id"))) shouldBe true
   }
 
   "CatchAll 404 route" should "be the first route in the list and a custom skipper route" in {

--- a/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
@@ -225,7 +225,7 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
 
     routes.size should not be 0
     routes.forall(_.metadata.routeDefinition.filters.contains(EnableAccessLog(List(2, 4, 5)))) shouldBe true
-    routes.forall(_.metadata.routeDefinition.filters.contains(AdminAuditing)) shouldBe true
+    routes.forall(_.metadata.routeDefinition.filters.contains(AccessLogAuditing("blah"))) shouldBe true
   }
 
   "CatchAll 404 route" should "be the first route in the list and a custom skipper route" in {
@@ -265,7 +265,7 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
       sr.predicates.exists { _.getClass == classOf[MethodMatch] } should be(true)
       sr.predicates.exists { _.getClass == classOf[UidMatch] } should be(true)
       sr.filters should equal(
-        List(NonCustomerRealm, EnableAccessLog(List(2, 4, 5)), AdminAuditing, RequiredPrivileges(NEL.of("uid")), FlowId, ForwardTokenInfo))
+        List(NonCustomerRealm, EnableAccessLog(List(2, 4, 5)), AccessLogAuditing(), RequiredPrivileges(NEL.of("uid")), FlowId, ForwardTokenInfo))
     }
 
     routes
@@ -712,6 +712,21 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
     nonCustomRoutes.foreach { nonCustomRoute =>
       val corsFilter = nonCustomRoute.metadata.routeDefinition.filters.filter(_.isInstanceOf[CorsOrigin])
       corsFilter shouldBe empty
+    }
+  }
+
+  "Access Logging" should "add the unverifiedAuditLog filter to all service routes with the sub key" in {
+    val ingresses = testableWhitelistRoutesDerivation(sampleGateway)
+
+    val filteredRoutes = ingresses
+      .filterNot(isAdminRoute)
+      .filterNot(isCatchAllRoute)
+      .filterNot(isHttpRejectRoute)
+      .map(_.metadata.routeDefinition.filters)
+
+    filteredRoutes should not be empty
+    filteredRoutes.foreach { filters: List[SkipperFilter] =>
+      filters should contain(AccessLogAuditing("sub"))
     }
   }
 


### PR DESCRIPTION
  * Add unverifiedAuditLog to all routes
  * Use sib for service routes
  * Use managed if for user routes
  * This change does not over-write the default accessLog values

Signed-off-by: bmooney <brian.mooney@zalando.ie>