### PR TITLE
MID-2558 Adding support for the use of named service ports 

### DIFF
--- a/src/it/resources/wiremock/__files/stack-set.json
+++ b/src/it/resources/wiremock/__files/stack-set.json
@@ -82,7 +82,7 @@
       },
       {
         "serviceName": "my-test-stackset-svc2",
-        "servicePort": 8080,
+        "servicePort": "http",
         "weight": 20
       }
     ]

--- a/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
@@ -445,7 +445,7 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
     case SchemaDefinedServices(svcMappings) => Future.successful(svcMappings)
     case StackSetProvidedServices(hosts, stackName) if hosts.nonEmpty =>
       stackSetOperations
-        .getStatus(StackSetIdentifer(stackName, namespace))
+        .getStatus(StackSetIdentifier(stackName, namespace))
         .map {
           case Some(status) =>
             status.traffic match {
@@ -455,7 +455,7 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
                     host,
                     services
                       .map(stackSvcDesc =>
-                        ServiceDescription(stackSvcDesc.serviceName, NumericServicePort(stackSvcDesc.servicePort), Some(stackSvcDesc.weight)))
+                        ServiceDescription(stackSvcDesc.serviceName, stackSvcDesc.servicePort, Some(stackSvcDesc.weight)))
                       .toSet)
                 }
               case _ =>

--- a/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
@@ -2,7 +2,6 @@ package ie.zalando.fabric.gateway.service
 
 import ie.zalando.fabric.gateway.models.SynchDomain.{K8sServicePortIdentifier, NamedServicePort, NumericServicePort}
 import org.slf4j.{Logger, LoggerFactory}
-import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import skuber._
 import skuber.api.client.KubernetesClient
@@ -26,21 +25,11 @@ class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: Executi
     case JsString(s) => JsSuccess(NamedServicePort(s))
     case other => Reads.IntReads.reads(other).map(NumericServicePort)
   }
+  
   implicit val servicePortWrites: Writes[K8sServicePortIdentifier] = {
     case NamedServicePort(name) => JsString(name)
     case NumericServicePort(port) => JsNumber(port)
   }
-  implicit val stackSvcReads: Reads[StackDefinedService] = (
-    (JsPath \ "serviceName").read[String] and
-      (JsPath \ "servicePort").read[K8sServicePortIdentifier] and
-      (JsPath \ "weight").read[Int]
-    ) (StackDefinedService.apply _)
-  
-  implicit val stackSvcWrites: Writes[StackDefinedService] = (
-    (JsPath \ "serviceName").write[String] and
-      (JsPath \ "servicePort").write[K8sServicePortIdentifier] and
-      (JsPath \ "weight").write[Int]
-    ) (unlift(StackDefinedService.unapply))
 
   implicit val stackSvcFmt: Format[StackDefinedService] = Json.format[StackDefinedService]
   implicit val stackIngressFmt: Format[StackSetIngress] = Json.format[StackSetIngress]

--- a/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
@@ -1,6 +1,8 @@
 package ie.zalando.fabric.gateway.service
 
+import ie.zalando.fabric.gateway.models.SynchDomain.{K8sServicePortIdentifier, NamedServicePort, NumericServicePort}
 import org.slf4j.{Logger, LoggerFactory}
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import skuber._
 import skuber.api.client.KubernetesClient
@@ -8,10 +10,10 @@ import skuber.api.client.KubernetesClient
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-case class StackSetIdentifer(name: String, namespace: String)
+case class StackSetIdentifier(name: String, namespace: String)
 case class StackSetIngress(backendPort: Int)
 case class StackSetSpec(externalIngress: Option[StackSetIngress])
-case class StackDefinedService(serviceName: String, servicePort: Int, weight: Int)
+case class StackDefinedService(serviceName: String, servicePort: K8sServicePortIdentifier, weight: Int)
 case class StackSetStatus(readyStacks: Int, stacks: Int, stacksWithTraffic: Int, traffic: Option[Seq[StackDefinedService]])
 
 class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: ExecutionContext) {
@@ -20,7 +22,27 @@ class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: Executi
 
   private type StackSet = CustomResource[StackSetSpec, StackSetStatus]
 
-  implicit val stackSvcFmt: Format[StackDefinedService] = Json.format[StackDefinedService]
+  implicit val servicePortReads: Reads[K8sServicePortIdentifier] = {
+    case JsString(s) => JsSuccess(NamedServicePort(s))
+    case other => Reads.IntReads.reads(other).map(NumericServicePort)
+  }
+  implicit val servicePortWrites: Writes[K8sServicePortIdentifier] = {
+    case NamedServicePort(name) => JsString(name)
+    case NumericServicePort(port) => JsNumber(port)
+  }
+  implicit val stackSvcReads: Reads[StackDefinedService] = (
+    (JsPath \ "serviceName").read[String] and
+      (JsPath \ "servicePort").read[K8sServicePortIdentifier] and
+      (JsPath \ "weight").read[Int]
+    ) (StackDefinedService.apply _)
+  
+  implicit val stackSvcWrites: Writes[StackDefinedService] = (
+    (JsPath \ "serviceName").write[String] and
+      (JsPath \ "servicePort").write[K8sServicePortIdentifier] and
+      (JsPath \ "weight").write[Int]
+    ) (unlift(StackDefinedService.unapply))
+
+  implicit val stackSvcFmt: Format[StackDefinedService] = Format(stackSvcReads, stackSvcWrites)
   implicit val stackIngressFmt: Format[StackSetIngress] = Json.format[StackSetIngress]
   implicit val specFmt: Format[StackSetSpec]            = Json.format[StackSetSpec]
   implicit val statusFmt: Format[StackSetStatus]        = Json.format[StackSetStatus]
@@ -31,7 +53,7 @@ class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: Executi
     version = "v1"
   )
 
-  def getStatus(stackSet: StackSetIdentifer): Future[Option[StackSetStatus]] = {
+  def getStatus(stackSet: StackSetIdentifier): Future[Option[StackSetStatus]] = {
     k8sClient
       .getInNamespace[StackSet](stackSet.name, stackSet.namespace)
       .map(_.status)

--- a/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
@@ -42,7 +42,7 @@ class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: Executi
       (JsPath \ "weight").write[Int]
     ) (unlift(StackDefinedService.unapply))
 
-  implicit val stackSvcFmt: Format[StackDefinedService] = Format(stackSvcReads, stackSvcWrites)
+  implicit val stackSvcFmt: Format[StackDefinedService] = Json.format[StackDefinedService]
   implicit val stackIngressFmt: Format[StackSetIngress] = Json.format[StackSetIngress]
   implicit val specFmt: Format[StackSetSpec]            = Json.format[StackSetSpec]
   implicit val statusFmt: Format[StackSetStatus]        = Json.format[StackSetStatus]

--- a/src/test/scala/ie/zalando/fabric/gateway/service/StackSetOperationsSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/StackSetOperationsSpec.scala
@@ -19,7 +19,7 @@ class StackSetOperationsSpec extends FlatSpec with Matchers {
     val k8sClient = k8sInit
     val ssOps     = new StackSetOperations(k8sClient)
 
-    val op = Await.result(ssOps.getStatus(StackSetIdentifer("fmoloney-traffic", "default")), 20.seconds)
+    val op = Await.result(ssOps.getStatus(StackSetIdentifier("fmoloney-traffic", "default")), 20.seconds)
 
     op match {
       case Some(status) => assert(status.traffic.isEmpty)


### PR DESCRIPTION
In StackSets status subResource, the  servicePorts property may either be numeric port (eg 8080) or a String named port (eg "http")

This PR adds support for both by writing custom play-json reader and writer functions to correctly marshal and unmarshal depending on the data type

Signed-off-by: Conor Gallagher <conor.gallagher@zalando.ie>