### PR TITLE
MID-2603 Adding support for fractional traffic weights.

### DIFF
--- a/src/it/resources/wiremock/__files/stack-set.json
+++ b/src/it/resources/wiremock/__files/stack-set.json
@@ -78,12 +78,12 @@
       {
         "serviceName": "my-test-stackset-svc1",
         "servicePort": 8080,
-        "weight": 80
+        "weight": 80.1
       },
       {
         "serviceName": "my-test-stackset-svc2",
         "servicePort": "http",
-        "weight": 20
+        "weight": 19.9
       }
     ]
   }

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -213,8 +213,8 @@ object SynchDomain {
       "^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9])$".r
     private val NonAlphaNumeric = "[^A-Za-z0-9]"
 
-    val DefaultRouteSuffix           = DnsString("-default-404-route")
-    val DefaultHttpRejectRouteSuffix = DnsString("-reject-http-route")
+    val DefaultRouteSuffix: DnsString = DnsString("-default-404-route")
+    val DefaultHttpRejectRouteSuffix: DnsString = DnsString("-reject-http-route")
 
     def apply(value: String) = new DnsString(value.toLowerCase)
 
@@ -225,10 +225,10 @@ object SynchDomain {
       if (isValidDnsName(input)) Some(DnsString(input))
       else None
 
-    def corsPath(verb: HttpVerb, path: PathMatch) =
+    def corsPath(verb: HttpVerb, path: PathMatch): DnsString =
       DnsString(s"-${verb.value}-${formatPath(path.path)}-cors")
 
-    def userAdminPath(verb: HttpVerb, path: PathMatch) =
+    def userAdminPath(verb: HttpVerb, path: PathMatch): DnsString =
       DnsString(s"-${verb.value}-${formatPath(path.path)}-admins")
 
     def rateLimitedServicePath(verb: HttpVerb, path: PathMatch, svc: String): DnsString =
@@ -240,10 +240,10 @@ object SynchDomain {
     def unlimitedUserPath(verb: HttpVerb, path: PathMatch): DnsString =
       DnsString(s"-${verb.value}-${formatPath(path.path)}-users-all")
 
-    def rateLimitedPath(verb: HttpVerb, path: PathMatch) =
+    def rateLimitedPath(verb: HttpVerb, path: PathMatch): DnsString =
       DnsString(s"-${verb.value}-${formatPath(path.path)}-rl-all")
 
-    def unlimitedPath(verb: HttpVerb, path: PathMatch) =
+    def unlimitedPath(verb: HttpVerb, path: PathMatch): DnsString =
       DnsString(s"-${verb.value}-${formatPath(path.path)}-all")
 
     def unlimitedServicePath(verb: HttpVerb, path: PathMatch, svc: String): DnsString =
@@ -287,13 +287,13 @@ object SynchDomain {
   case class NamedServicePort(name: String) extends K8sServicePortIdentifier
   case class NumericServicePort(port: Int) extends K8sServicePortIdentifier
 
-  val DefaultIngressServiceProtocol = NamedServicePort("http")
+  val DefaultIngressServiceProtocol: NamedServicePort = NamedServicePort("http")
 
   case class FabricServiceDefinition(host: String, service: String, port: K8sServicePortIdentifier)
 
   case class ServiceDescription(name: String,
                                 portIdentifier: K8sServicePortIdentifier = DefaultIngressServiceProtocol,
-                                trafficWeight: Option[Int] = None)
+                                trafficWeight: Option[Double] = None)
   case class IngressBackend(host: String, services: Set[ServiceDescription])
 
   case class IngressDefinition(hostMappings: Set[IngressBackend], metadata: IngressMetaData)

--- a/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
@@ -481,7 +481,7 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
     val creatableRoutes = if (backends.isEmpty) Nil else routes
 
     creatableRoutes.map { skipperRoute =>
-      val serviceWeights: Set[(String, Int)] = backends
+      val serviceWeights: Set[(String, Double)] = backends
         .flatMap(
           _.services
             .map(svc => (svc.name, svc.trafficWeight))
@@ -513,7 +513,7 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
     }
   }
 
-  def createBackendWeightsAnnotation(serviceWeights: Set[(String, Int)]): Map[String, String] = {
+  def createBackendWeightsAnnotation(serviceWeights: Set[(String, Double)]): Map[String, String] = {
     if (serviceWeights.isEmpty) Map.empty[String, String]
     else
       Map(

--- a/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success}
 case class StackSetIdentifier(name: String, namespace: String)
 case class StackSetIngress(backendPort: Int)
 case class StackSetSpec(externalIngress: Option[StackSetIngress])
-case class StackDefinedService(serviceName: String, servicePort: K8sServicePortIdentifier, weight: Int)
+case class StackDefinedService(serviceName: String, servicePort: K8sServicePortIdentifier, weight: Double)
 case class StackSetStatus(readyStacks: Int, stacks: Int, stacksWithTraffic: Int, traffic: Option[Seq[StackDefinedService]])
 
 class StackSetOperations(k8sClient: KubernetesClient)(implicit execCtxt: ExecutionContext) {


### PR DESCRIPTION
Signed-off-by: Conor Gallagher <conor.gallagher@zalando.ie>
The lack of support for fractional traffic weights was a bug in the original  implementation of the Stackset integration. As can be seen in StackSets code, traffic weight is defined as a go `float64`
```
// Traffic is the actual traffic setting on services for this
// stackset, controllers interested in current traffic decision should
// read this.
type ActualTraffic struct {
	StackName   string             `json:"stackName"`
	ServiceName string             `json:"serviceName"`
	ServicePort intstr.IntOrString `json:"servicePort"`
	Weight      float64            `json:"weight"`
}
```
https://github.com/zalando-incubator/stackset-controller/blob/master/pkg/apis/zalando.org/v1/types.go#L182