### PR TITLE
MID-2742 Propagating metadata labels 

### DIFF
--- a/src/it/resources/synch/sampleSynchRequest.json
+++ b/src/it/resources/synch/sampleSynchRequest.json
@@ -51,6 +51,10 @@
       "annotations": {
         "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"zalando.org/v1\",\"kind\":\"FabricGateway\",\"metadata\":{\"annotations\":{},\"name\":\"my-app-gateway\",\"namespace\":\"default\"},\"spec\":{\"paths\":{\"/api/resource\":{\"post\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimits\":{\"default-rate\":10,\"period\":\"minute\",\"target\":{\"spp_service_name\":50}}}},\"/api/resource/*\":{\"get\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.read\"]}},\"patch\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimit\":{\"default-rate\":10}},\"put\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimit\":{\"default-rate\":10}}},\"/events\":{\"post\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.read\"]}}}},\"service\":{\"host\":\"my-app.smart-product-platform-test.zalan.do\",\"serviceName\":\"my-app-service-name\"},\"whitelist\":[\"jblogs\"]}}\n"
       },
+      "labels": {
+        "application": "my-app-id",
+        "component": "my-component-label"
+      },
       "clusterName": "",
       "creationTimestamp": "2018-09-07T07:57:57Z",
       "generation": 1,

--- a/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
+++ b/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
@@ -19,7 +19,7 @@ import skuber.k8sInit
 import scala.concurrent.duration._
 
 class ApiValidationSpec
-  extends FlatSpec
+    extends FlatSpec
     with MockitoSugar
     with Matchers
     with ScalatestRouteTest
@@ -29,8 +29,8 @@ class ApiValidationSpec
     with BeforeAndAfterEach {
 
   val kubernetesClient: KubernetesClient = k8sInit
-  val stackSetOperations = new StackSetOperations(kubernetesClient)
-  val ingressDerivationLogic = new IngressDerivationChain(stackSetOperations, None)
+  val stackSetOperations                 = new StackSetOperations(kubernetesClient)
+  val ingressDerivationLogic             = new IngressDerivationChain(stackSetOperations, None)
 
   var wireMockServer: WireMockServer = _
 
@@ -108,11 +108,12 @@ class ApiValidationSpec
 
   it should "ensure that all admin routes have extra auditing enabled" in {
     synchRequest(ValidSynchRequest.payload) ~> Route.seal(createRoutesFromDerivations(ingressDerivationLogic)) ~> check {
-      val ingressii = responseAs[TestSynchResponse].ingressii
+      val ingressii   = responseAs[TestSynchResponse].ingressii
       val adminRoutes = ingressii.filter(_.name.contains("admins")).map(_.filters.get)
       adminRoutes should not be empty
       adminRoutes.foreach { filterChain =>
-        filterChain should include("""enableAccessLog(2, 4, 5) -> unverifiedAuditLog("https://identity.zalando.com/managed-id")""")
+        filterChain should include(
+          """enableAccessLog(2, 4, 5) -> unverifiedAuditLog("https://identity.zalando.com/managed-id")""")
       }
     }
   }
@@ -193,7 +194,7 @@ class ApiValidationSpec
       val ingressii = responseAs[TestSynchResponse].ingressii
       ingressii should have length 13
       ingressii.map(_.rules.head.paths.map(_.serviceName)).foreach { backends =>
-        backends should contain only("my-test-stackset-svc1", "my-test-stackset-svc2")
+        backends should contain only ("my-test-stackset-svc1", "my-test-stackset-svc2")
       }
     }
   }
@@ -205,23 +206,26 @@ class ApiValidationSpec
   }
 
   it should "add extra gateways with versioned hosts for a stackset-managed gateway when configured" in {
-    synchRequest(ValidSynchRequestWithStackSetManagedServices.payload) ~> Route.seal(
-      createRoutesFromDerivations(new IngressDerivationChain(stackSetOperations, Some("smart-product-platform-test.zalan.do")))) ~> check {
+    synchRequest(ValidSynchRequestWithStackSetManagedServices.payload) ~> Route.seal(createRoutesFromDerivations(
+      new IngressDerivationChain(stackSetOperations, Some("smart-product-platform-test.zalan.do")))) ~> check {
       val ingressii = responseAs[TestSynchResponse].ingressii
 
       val mainIngressii = ingressii.filter(_.rules.map(_.host).contains("my-app.smart-product-platform-test.zalan.do"))
-      val versionedHost1 = ingressii.filter(_.rules.map(_.host).contains("my-test-stackset-svc1.smart-product-platform-test.zalan.do"))
-      val versionedHost2 = ingressii.filter(_.rules.map(_.host).contains("my-test-stackset-svc2.smart-product-platform-test.zalan.do"))
+      val versionedHost1 =
+        ingressii.filter(_.rules.map(_.host).contains("my-test-stackset-svc1.smart-product-platform-test.zalan.do"))
+      val versionedHost2 =
+        ingressii.filter(_.rules.map(_.host).contains("my-test-stackset-svc2.smart-product-platform-test.zalan.do"))
 
       mainIngressii should have length 13
       versionedHost1 should have length 13
       versionedHost2 should have length 13
 
       mainIngressii.flatMap(_.rules.map(_.paths.map(_.serviceName))).foreach { backends =>
-        backends should contain only("my-test-stackset-svc1", "my-test-stackset-svc2")
+        backends should contain only ("my-test-stackset-svc1", "my-test-stackset-svc2")
       }
       mainIngressii.map(_.allAnnos).foreach { annos =>
-        annos should contain("zalando.org/backend-weights" -> Json.fromString("{\"my-test-stackset-svc1\":80.1,\"my-test-stackset-svc2\":19.9}"))
+        annos should contain(
+          "zalando.org/backend-weights" -> Json.fromString("{\"my-test-stackset-svc1\":80.1,\"my-test-stackset-svc2\":19.9}"))
       }
       versionedHost1.flatMap(_.rules.map(_.paths.map(_.serviceName))).foreach { backends =>
         backends should contain only "my-test-stackset-svc1"

--- a/src/it/scala/ie/zalando/fabric/gateway/TestJsonModels.scala
+++ b/src/it/scala/ie/zalando/fabric/gateway/TestJsonModels.scala
@@ -16,7 +16,8 @@ object TestJsonModels {
                              route: Option[String],
                              predicates: Option[String],
                              filters: Option[String],
-                             allAnnos: Map[String, Json])
+                             allAnnos: Map[String, Json],
+                             labels: Option[Map[String, String]])
   case class TestSynchResponse(ingressii: List[TestableIngress])
 
   case class TestValidationResponseStatus(reason: String)
@@ -52,7 +53,8 @@ trait TestJsonModels extends JsonModels with FailFastCirceSupport {
                           .as[Option[String]]
       maybeFilters <- c.downField("metadata").downField("annotations").downField("zalando.org/skipper-filter").as[Option[String]]
       allAnnos     <- c.downField("metadata").downField("annotations").as[Map[String, Json]]
-    } yield TestableIngress(name, namespace, rules, maybeCustomRoute, maybePredicates, maybeFilters, allAnnos)
+      labels <- c.downField("metadata").downField("labels").as[Option[Map[String, String]]]
+    } yield TestableIngress(name, namespace, rules, maybeCustomRoute, maybePredicates, maybeFilters, allAnnos, labels)
 
   implicit val decodeSynchResponse: Decoder[TestSynchResponse] = (c: HCursor) =>
     for {

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -281,7 +281,10 @@ object SynchDomain {
                                     customRoute: Option[SkipperCustomRoute],
                                     additionalAnnotations: Map[String, String] = Map.empty)
 
-  case class IngressMetaData(routeDefinition: SkipperRouteDefinition, name: String, namespace: String)
+  case class IngressMetaData(routeDefinition: SkipperRouteDefinition, 
+                             name: String, 
+                             namespace: String, 
+                             labels: Option[Map[String, String]] = None)
 
   sealed trait K8sServicePortIdentifier
   case class NamedServicePort(name: String) extends K8sServicePortIdentifier
@@ -344,7 +347,7 @@ object SynchDomain {
                          corsConfig: Option[CorsConfig],
                          paths: GatewayPaths)
 
-  case class GatewayMeta(name: DnsString, namespace: String)
+  case class GatewayMeta(name: DnsString, namespace: String, labels: Option[Map[String, String]] = None)
 
   case class GatewayStatus(numOwnedIngress: Int, ownedIngress: Set[String])
 

--- a/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/IngressDerivationChain.scala
@@ -507,7 +507,8 @@ class IngressDerivationChain(stackSetOperations: StackSetOperations, versionedHo
         IngressMetaData(
           annotatedRoute,
           annotatedRoute.name.value,
-          meta.namespace
+          meta.namespace,
+          meta.labels
         )
       )
     }

--- a/src/main/scala/ie/zalando/fabric/gateway/web/marshalling/JsonModels.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/web/marshalling/JsonModels.scala
@@ -197,6 +197,7 @@ trait JsonModels {
     for {
       name      <- c.downField("name").as[String]
       namespace <- c.downField("namespace").as[String]
+      labels    <- c.downField("labels").as[Option[Map[String, String]]]
     } yield {
       val dnsCompliantGatewayName = DnsString
         .fromString(name)
@@ -205,7 +206,7 @@ trait JsonModels {
           logger.warn(s"Gateway name [$name] is not DNS compliant. Using $gwName instead")
           gwName
         })
-      GatewayMeta(dnsCompliantGatewayName, namespace)
+      GatewayMeta(dnsCompliantGatewayName, namespace, labels)
   }
 
   implicit val decodeSynchParent: Decoder[ControlledGatewayResource] = (c: HCursor) =>
@@ -256,7 +257,8 @@ trait JsonModels {
       .deepMerge(route.additionalAnnotations.asJson)
 
   implicit val encodeIngressMetaData: Encoder[IngressMetaData] =
-    Encoder.forProduct3("annotations", "namespace", "name")(meta => (meta.routeDefinition, meta.namespace, meta.name))
+    Encoder.forProduct4("annotations", "namespace", "name", "labels")(meta => 
+      (meta.routeDefinition, meta.namespace, meta.name, meta.labels))
 
   implicit val encodeGatewayOwnershipState: Encoder[GatewayStatus] =
     Encoder.forProduct2("num_owned_ingress", "owned_ingress_names")(state => (state.numOwnedIngress, state.ownedIngress))

--- a/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
@@ -469,7 +469,7 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
         ingressDef.metadata.name.contains("non-whitelisted")
       }
       .collect {
-        case IngressDefinition(_, IngressMetaData(SkipperRouteDefinition(_, _, _, Some(customRoute), _), _, _)) => customRoute
+        case IngressDefinition(_, IngressMetaData(SkipperRouteDefinition(_, _, _, Some(customRoute), _), _, _, None)) => customRoute
       }
     routes.size shouldBe 2
     routes.forall { route =>


### PR DESCRIPTION
This ensures that all labels defined on a `FabricGateway` resource are propagated to the generated `Ingress` resources

Signed-off-by: Conor Gallagher <conor.gallagher@zalando.ie>