### PR TITLE
MID-2836: Route Weights

### DIFF
--- a/design/ArtificallyWeightingRoutes.md
+++ b/design/ArtificallyWeightingRoutes.md
@@ -1,0 +1,71 @@
+# Artifical Route Weighting
+One important concept to understand about the Gateway is that it is merely a control plane for Skipper Ingress.  When you create a gateway K8s resource, the operator creates many Skipper Ingress resources on your behalf with specific [Predicate](https://opensource.zalando.com/skipper/reference/predicates/) and [Filter](https://opensource.zalando.com/skipper/reference/filters/) combinations to match the traffic as you decribe in your gateway yaml. In Skipper terms, predicates are used to match an incoming request and filters are used to apply transformations on a request and potentially return a static result instead of forwarding to the defined backend. Below is an example request flow for your application:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant AWS Load Balancer
+    participant Skipper Proxy
+    participant Backend Svc 1
+    participant Backend Svc 2
+    Client->>AWS Load Balancer: HTTPS Request
+    Note right of Skipper Proxy: All traffic flow through Skipper where the requests <br/>will be matched by evaluating defined predicates<br/> against the route. Precedence rules dictate<br/> that the route with the most matching predicates<br/> wins. This route then decides what filters to<br/> execute on the request and which backend<br/> to forward the request to.
+    AWS Load Balancer->>Skipper Proxy: Forward HTTP traffic
+    loop Route Lookup
+        Skipper Proxy->>Backend Svc 1: Match incoming request to backend using Predicates
+    end
+    Backend Svc 1-->>Skipper Proxy: Svc Response
+    Skipper Proxy-->>AWS Load Balancer: Proxied Response
+    AWS Load Balancer-->>Client: HTTPS Respone
+```
+
+## Route Precedence
+For an incoming request to match a route in Skipper, all the predicates need to evaluate to true. If multiple routes all evaluated to true then the route with the highest precedence is the route which is selected. If two or more routes have the same precedence then it is non-deterministic as to which route will be selected. Skipper automatically adds a Host predicate to each route that we define in the Gateway already, which helps limit the number of incoming requests that could be matched. From there, route precendence is calculated by the number of predicates which match.         
+
+An example of the precedence rules for the routes that may exist for a sample gateway. In this example a request is coming from an employee token which is defined as an admin of the service:    
+Example request:
+```bash
+  curl -X POST -d @payload.json -H "Content-Type: application/json" -H "Authorization: Bearer $(ztoken) https://ingress.url/restricted"
+```
+
+| Name  | Predicates | Score | Matched | Selected | Notes |
+|-------|------------|-------|---------|----------|-------|
+| Default Route Not Found | [PathSubTree](https://opensource.zalando.com/skipper/reference/predicates/#pathsubtree)          |  1     |  Y       | N  |  This is used as an informational fallback to show the client that no routes owned by the gateway have matched the incoming request. Although the predicates match, this route isn't chosen because it has a low precedence score    |
+| Reject HTTP Traffic | [PathSubTree](https://opensource.zalando.com/skipper/reference/predicates/#pathsubtree) && [Header](https://opensource.zalando.com/skipper/reference/predicates/#header)           |  2     | X       | N | Checks the forwarded protocol header from AWS LB and rejects the request if it was http      |
+| Admin | [Path](https://opensource.zalando.com/skipper/reference/predicates/#path) && [Method](https://opensource.zalando.com/skipper/reference/predicates/#method) && [JWTPayloadAnyKV](https://opensource.zalando.com/skipper/reference/predicates/#jwtpayloadanykv) && [Header](https://opensource.zalando.com/skipper/reference/predicates/#header) | 4 | Y | Y | This is the route which the HTTP request matches as it has the highest number of successfully evaluated predicates |
+| Non-Whitelisted Reject Route | [Path](https://opensource.zalando.com/skipper/reference/predicates/#path) && [Method](https://opensource.zalando.com/skipper/reference/predicates/#method) && [Header](https://opensource.zalando.com/skipper/reference/predicates/#header)  | 3 | Y | N | This is used as an informational fallback for clients who are not whitelisted. Although the predicates match, this route isn't chosen because it has a lower precedence score |
+| Service Specific Rate Limit Route | [Path](https://opensource.zalando.com/skipper/reference/predicates/#path) && [Method](https://opensource.zalando.com/skipper/reference/predicates/#method) && [JWTPayloadAnyKV](https://opensource.zalando.com/skipper/reference/predicates/#jwtpayloadanykv) && [Header](https://opensource.zalando.com/skipper/reference/predicates/#header) | 4 | N | N | This route is not matched because the Token Introspection is specifically looking for a service name |
+| User Specific Rate Limit Route | [Path](https://opensource.zalando.com/skipper/reference/predicates/#path) && [Method](https://opensource.zalando.com/skipper/reference/predicates/#method) && [JWTPayloadAnyKV](https://opensource.zalando.com/skipper/reference/predicates/#jwtpayloadanykv) && [Header](https://opensource.zalando.com/skipper/reference/predicates/#header) | 4 | N | N | This route is not matched because the Token Introspection is specifically looking for a user name |
+
+Below is a sample gateway resource which the above routes were generated from
+```yaml
+    apiVersion: zalando.org/v1
+    kind: FabricGateway
+    metadata:
+      name: example
+    spec:
+      x-external-service-provider:
+        stackSetName: some_stackset
+        hosts:
+          - ingress.url
+      x-fabric-admins:
+        - bmooney
+      x-fabric-whitelist:
+        - stups_service_name
+      paths:
+        /restricted:
+          post:
+            x-fabric-privileges:
+              - some.write.scope
+            x-fabric-employee-access:
+              user-list:
+                - jbloggs
+            x-fabric-ratelimits:
+              default-rate: 10
+              period: minute
+              target:
+                stups_service_name: 50
+```
+
+### Manual Weighting
+There was an issue discovered with how Skipper does traffic switching when running in tandem with Stacksets. Skipper will automatically add a Traffic predicate to one of the backend routes which can change the route precedence. So in the example we saw, admin requests where sometimes matched against service routes and service specific rate limits where degraded to the global rate limit. This is why we now add a specific [Weight](https://opensource.zalando.com/skipper/reference/predicates/#weight-priority) predicate to each of the routes to ensure that there is more than a precedence gap of 1 to avoid non-deterministic matching whn Skipper is adding these Traffic predicates.

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -3,6 +3,7 @@ package ie.zalando.fabric.gateway.models
 import akka.http.scaladsl.model.Uri
 import cats.Show
 import cats.data.NonEmptyList
+import ie.zalando.fabric.gateway.service.RouteDerivationModels.WeightedGatewayFeature
 
 object SynchDomain {
 
@@ -84,6 +85,10 @@ object SynchDomain {
 
   case object HttpsTraffic extends SkipperPredicate {
     val skipperStringValue: String = s"""Header("X-Forwarded-Proto", "https")"""
+  }
+
+  case class WeightedRoute(featureWeight: WeightedGatewayFeature) extends SkipperPredicate {
+    val skipperStringValue: String = s"""Weight(${featureWeight.weight})"""
   }
 
   case object NonCustomerRealm extends SkipperFilter {

--- a/src/main/scala/ie/zalando/fabric/gateway/service/FeatureDerivation.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/FeatureDerivation.scala
@@ -1,0 +1,94 @@
+package ie.zalando.fabric.gateway.service
+
+import ie.zalando.fabric.gateway.models.SynchDomain.{Disabled, Enabled, Inherited, Skipper}
+import ie.zalando.fabric.gateway.service.RouteDerivationModels.{GatewayFeatureDerivation, GenericServiceMatch, NamedService, RateLimitDetails, RequiredScope, ServiceIdentifier, ServiceRestrictionDetails, UserRestrictionDetails}
+
+object FeatureDerivation {
+
+  val authentication: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      (route, config.copy(tokenValidations = config.tokenValidations + RequiredScope(Skipper.ZalandoTokenId)), context)
+  }
+
+  val authorization: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      val requiredScopes = context.gateway.paths
+        .get(route.path)
+        .flatMap { ctxtPathConf =>
+          ctxtPathConf.operations.get(route.verb).flatMap { gwActions =>
+            Some(
+              gwActions.requiredPrivileges.toList
+                .filterNot(_.toUpperCase == "UID")
+                .map(RequiredScope)
+                .toSet)
+          }
+        }
+        .getOrElse(Set.empty)
+
+      (route, config.copy(tokenValidations = config.tokenValidations ++ requiredScopes), context)
+  }
+
+  val adminAccess: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      (route, config.copy(adminAccessForRoute = context.gateway.admins), context)
+  }
+
+  val whitelisting: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      val globalWhitelistConfig = context.gateway.globalWhitelistConfig
+
+      (for {
+        pathConf <- context.gateway.paths.get(route.path)
+        opConf   <- pathConf.operations.get(route.verb)
+      } yield {
+        (opConf.resourceWhitelistConfig.state, globalWhitelistConfig.state) match {
+          case (Inherited, Inherited | Enabled) =>
+            (route,
+              config.copy(
+                serviceRestrictions = ServiceRestrictionDetails(isRouteRestricted = true, globalWhitelistConfig.services)),
+              context)
+          case (Inherited, Disabled) | (Disabled, _) =>
+            (route,
+              config.copy(serviceRestrictions = ServiceRestrictionDetails(isRouteRestricted = false, Set.empty[String])),
+              context)
+          case (Enabled, _) =>
+            (route,
+              config.copy(serviceRestrictions =
+                ServiceRestrictionDetails(isRouteRestricted = true, opConf.resourceWhitelistConfig.services)),
+              context)
+        }
+      }) getOrElse ((route, config, context))
+  }
+
+  val employeeAccess: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      (for {
+        pathConf             <- context.gateway.paths.get(route.path)
+        opConf               <- pathConf.operations.get(route.verb)
+        employeeAccessConfig = opConf.employeeAccessConfig
+      } yield {
+        (route, config.copy(userRestrictions = UserRestrictionDetails(employeeAccessConfig.employees)), context)
+      }) getOrElse ((route, config, context))
+  }
+
+  val rateLimiting: GatewayFeatureDerivation = {
+    case (route, config, context) =>
+      (for {
+        pathConf      <- context.gateway.paths.get(route.path)
+        opConf        <- pathConf.operations.get(route.verb)
+        rateLimitConf <- opConf.rateLimit
+      } yield {
+        val defaultRateLimits: Map[ServiceIdentifier, RateLimitDetails] =
+          Map(GenericServiceMatch -> RateLimitDetails(rateLimitConf.defaultReqRate, rateLimitConf.period))
+        val allRateLimits = rateLimitConf.uidSpecific.foldLeft(defaultRateLimits) {
+          case (accum, (id, limit)) =>
+            if (config.adminAccessForRoute.contains(id))
+              accum
+            else
+              accum + (NamedService(id) -> RateLimitDetails(limit, rateLimitConf.period))
+        }
+
+        (route, config.copy(rateLimitDetails = allRateLimits), context)
+      }) getOrElse ((route, config, context))
+  }
+}

--- a/src/main/scala/ie/zalando/fabric/gateway/service/RouteDerivationModels.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/RouteDerivationModels.scala
@@ -1,0 +1,46 @@
+package ie.zalando.fabric.gateway.service
+
+import ie.zalando.fabric.gateway.models.SynchDomain.{GatewayMeta, GatewaySpec, HttpVerb, PathMatch, RateLimitPeriod}
+
+object RouteDerivationModels {
+
+  // Weights used to avoid collisions from conditional predicates added in Skipper
+  sealed trait WeightedGatewayFeature {
+    def weight: Int
+  }
+
+  object Admin extends WeightedGatewayFeature { val weight = 100 }
+  object SvcRateLimit extends WeightedGatewayFeature { val weight = 80 }
+  object SvcWhitelist extends WeightedGatewayFeature { val weight = 80 }
+  object UserRateLimit extends WeightedGatewayFeature { val weight = 80 }
+  object UserWhitelist extends WeightedGatewayFeature { val weight = 80 }
+  object GlobalRateLimit extends WeightedGatewayFeature { val weight = 60 }
+  object RejectNonWhitelisted extends WeightedGatewayFeature { val weight = 40 }
+  object SvcMatch extends WeightedGatewayFeature { val weight = 40 }
+
+  // Type used to for building a feature set and converting to a Skipper route type
+  case class GatewayContext(gateway: GatewaySpec, meta: GatewayMeta)
+  case class Route(path: PathMatch, verb: HttpVerb)
+
+  case class RequiredScope(name: String)
+
+  sealed trait ServiceIdentifier
+  case object GenericServiceMatch       extends ServiceIdentifier
+  case class NamedService(name: String) extends ServiceIdentifier
+
+  case class ServiceRestrictionDetails(isRouteRestricted: Boolean, restrictedTo: Set[String])
+  case class UserRestrictionDetails(restrictedTo: Set[String])
+  case class RateLimitDetails(rate: Int, period: RateLimitPeriod)
+
+  case class RouteConfig(
+                          tokenValidations: Set[RequiredScope] = Set.empty,
+                          adminAccessForRoute: Set[String] = Set.empty,
+                          serviceRestrictions: ServiceRestrictionDetails = ServiceRestrictionDetails(isRouteRestricted = false, Set.empty),
+                          userRestrictions: UserRestrictionDetails = UserRestrictionDetails(Set.empty),
+                          rateLimitDetails: Map[ServiceIdentifier, RateLimitDetails] = Map.empty
+                        )
+
+  type FlowContext = (Route, RouteConfig, GatewayContext)
+
+  type GatewayFeatureDerivation = FlowContext => FlowContext
+}

--- a/src/test/scala/ie/zalando/fabric/gateway/service/RouteWeightingsSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/RouteWeightingsSpec.scala
@@ -1,0 +1,68 @@
+package ie.zalando.fabric.gateway.service
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import ie.zalando.fabric.gateway.models.SynchDomain._
+import ie.zalando.fabric.gateway.web.marshalling.JsonModels
+import ie.zalando.fabric.gateway.service.TestUtils._
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+import skuber.api.client.KubernetesClient
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
+
+class RouteWeightingsSpec extends FlatSpec with MockitoSugar with Matchers with JsonModels {
+
+  implicit val ec: ExecutionContext   = ExecutionContext.global
+  implicit val as: ActorSystem        = ActorSystem()
+  implicit val mat: ActorMaterializer = ActorMaterializer()
+
+  val kubernetesClient       = mock[KubernetesClient]
+  val stackSetOperations     = new StackSetOperations(kubernetesClient)
+  val ingressDerivationLogic = new IngressDerivationChain(stackSetOperations, None)
+
+  val testableRouteDerivation: List[IngressDefinition] =
+    Await.result(ingressDerivationLogic.deriveRoutesFor(sampleGateway,
+      GatewayMeta(DnsString.fromString("gateway-name").get, "my-namespace")),
+      10.seconds)
+
+  "Route Weights" should "be higher for admin after dynamic traffic predicate is added to svc routes" in {
+    val adminRouteWeight = testableRouteDerivation
+      .filter { isAdminRoute }
+      .map { route => route.metadata.routeDefinition.predicates }
+      .find { routes => routes.contains(PathMatch("/api/resource/*"))}
+      .get.foldLeft(0) { sumWeights }
+
+    val svcRouteWeight = testableRouteDerivation
+      .filter { isStandardServiceRoute }
+      .map { route => route.metadata.routeDefinition.predicates }
+      .find { routes => routes.contains(PathMatch("/api/resource/*"))}
+      .get.foldLeft(0) { sumWeights }
+
+    adminRouteWeight should be > svcRouteWeight
+    adminRouteWeight should be > (svcRouteWeight + 1) // To cover dynamic Traffic predicate
+  }
+
+  it should "be higher for svc specific rate limit routes than global rate limit routes" in {
+    val svcSpecificRateLimitedRoute = testableRouteDerivation
+      .filter { isTargettedRateLimitRoute }
+      .map { route => route.metadata.routeDefinition.predicates }
+      .find { routes => routes.contains(PathMatch("/api/resource"))}
+      .get.foldLeft(0) { sumWeights }
+
+    val globalRateLimitedRoute = testableRouteDerivation
+      .filter { isGlobalRateLimitRoute }
+      .map { route => route.metadata.routeDefinition.predicates }
+      .find { routes => routes.contains(PathMatch("/api/resource"))}
+      .get.foldLeft(0) { sumWeights }
+
+    svcSpecificRateLimitedRoute should be > globalRateLimitedRoute
+    svcSpecificRateLimitedRoute should be > (globalRateLimitedRoute + 1) // To cover dynamic Traffic predicate
+  }
+
+  private def sumWeights(sum: Int, predicate: SkipperPredicate): Int = sum + (predicate match {
+      case WeightedRoute(weight) => weight.weight
+      case _ => 1
+    })
+}

--- a/src/test/scala/ie/zalando/fabric/gateway/service/TestUtils.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/TestUtils.scala
@@ -1,0 +1,230 @@
+package ie.zalando.fabric.gateway.service
+
+import akka.http.scaladsl.model.Uri
+import cats.data.{NonEmptyList => NEL}
+import ie.zalando.fabric.gateway.models.SynchDomain._
+
+object TestUtils {
+
+  // Test Data
+  val AdminUser                 = "adminUser"
+  val WhitelistedUser           = "whitelistedUser"
+  val ResourceWhitelistedUser   = "resourceWhitelistedUser"
+  val InheritedWhitelistDetails = WhitelistConfig(Set(), Inherited)
+  val UserWhitelist             = EmployeeAccessConfig(Set.empty)
+  val EnabledCors = Some(
+    CorsConfig(Set(Uri.from(host = "example.com"), Uri.from(host = "example-other.com")),
+               Set("Content-Type", "Authorization", "X-Flow-id")))
+  val DisabledCors: Option[CorsConfig] = None
+
+  val sampleGateway = GatewaySpec(
+    SchemaDefinedServices(Set(IngressBackend("host", Set(ServiceDescription("svc"))))),
+    Set(AdminUser),
+    WhitelistConfig(Set(), Disabled),
+    DisabledCors,
+    Map(
+      PathMatch("/api/resource") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            Some(RateLimitDetails(10, PerMinute, Map.empty[String, Int])),
+            InheritedWhitelistDetails,
+            UserWhitelist
+          ),
+          Post -> ActionAuthorizations(
+            NEL.of("uid", "service.write"),
+            Some(
+              RateLimitDetails(10,
+                               PerMinute,
+                               Map(
+                                 AdminUser   -> 25,
+                                 "otherUser" -> 35
+                               ))),
+            InheritedWhitelistDetails,
+            UserWhitelist
+          )
+        )),
+      PathMatch("/api/resource/*") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            None,
+            InheritedWhitelistDetails,
+            UserWhitelist
+          )
+        ))
+    )
+  )
+
+  val sampleGloballyWhitelistedGateway = GatewaySpec(
+    SchemaDefinedServices(Set(IngressBackend("host", Set(ServiceDescription("svc", NamedServicePort("named")))))),
+    Set(AdminUser),
+    WhitelistConfig(Set(WhitelistedUser), Enabled),
+    DisabledCors,
+    Map(
+      PathMatch("/api/resource") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            Some(RateLimitDetails(10, PerMinute, Map.empty[String, Int])),
+            InheritedWhitelistDetails,
+            UserWhitelist
+          ),
+          Post -> ActionAuthorizations(
+            NEL.of("uid", "service.write"),
+            Some(
+              RateLimitDetails(10,
+                               PerMinute,
+                               Map(
+                                 AdminUser       -> 25,
+                                 WhitelistedUser -> 25,
+                                 "otherUser"     -> 35
+                               ))),
+            InheritedWhitelistDetails,
+            UserWhitelist
+          )
+        )),
+      PathMatch("/api/resource/*") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            None,
+            InheritedWhitelistDetails,
+            UserWhitelist
+          ))
+      )
+    )
+  )
+
+  val sampleResourceWhitelistingGateway = GatewaySpec(
+    SchemaDefinedServices(Set(IngressBackend("host", Set(ServiceDescription("svc", NamedServicePort("named")))))),
+    Set(AdminUser),
+    WhitelistConfig(Set(WhitelistedUser), Enabled),
+    DisabledCors,
+    Map(
+      PathMatch("/api/resource") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            Some(RateLimitDetails(10, PerMinute, Map.empty[String, Int])),
+            InheritedWhitelistDetails,
+            UserWhitelist
+          ),
+          Post -> ActionAuthorizations(
+            NEL.of("uid", "service.write"),
+            Some(
+              RateLimitDetails(10,
+                               PerMinute,
+                               Map(
+                                 AdminUser       -> 25,
+                                 WhitelistedUser -> 25,
+                                 "otherUser"     -> 35
+                               ))),
+            WhitelistConfig(Set(ResourceWhitelistedUser), Enabled),
+            UserWhitelist
+          )
+        )),
+      PathMatch("/api/resource/*") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            None,
+            WhitelistConfig(Set(), Disabled),
+            UserWhitelist
+          )
+        ))
+    )
+  )
+
+  val sampleUserWhitelistingGateway = GatewaySpec(
+    SchemaDefinedServices(Set(IngressBackend("host", Set(ServiceDescription("svc", NamedServicePort("named")))))),
+    Set(AdminUser),
+    WhitelistConfig(Set(WhitelistedUser), Enabled),
+    DisabledCors,
+    Map(
+      PathMatch("/api/resource") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            None,
+            InheritedWhitelistDetails,
+            EmployeeAccessConfig(Set(WhitelistedUser))
+          ),
+          Post -> ActionAuthorizations(
+            NEL.of("uid", "service.write"),
+            None,
+            WhitelistConfig(Set(ResourceWhitelistedUser), Enabled),
+            UserWhitelist
+          )
+        )),
+      PathMatch("/api/resource/*") -> PathConfig(
+        Map(
+          Get -> ActionAuthorizations(
+            NEL.of("uid", "service.read"),
+            Some(RateLimitDetails(10, PerMinute, Map.empty[String, Int])),
+            WhitelistConfig(Set(), Disabled),
+            EmployeeAccessConfig(Set(WhitelistedUser))
+          )
+        ))
+    )
+  )
+
+  // Utility Functions
+  def isAdminRoute(route: IngressDefinition): Boolean = {
+    val defn = route.metadata.routeDefinition
+    defn.customRoute.isEmpty &&
+    !defn.filters.exists(_.getClass == classOf[GlobalRouteRateLimit]) &&
+    !defn.filters.exists(_.getClass == classOf[ClientSpecificRouteRateLimit]) &&
+    route.metadata.name.endsWith("admins")
+  }
+
+  def isCorsRoute(route: IngressDefinition): Boolean = {
+    val metadata = route.metadata
+    metadata.name.contains("-cors") && metadata.routeDefinition.customRoute.isDefined
+  }
+
+  def isWhitelistedUserRoute(route: IngressDefinition): Boolean = {
+    val defn = route.metadata.routeDefinition
+    defn.customRoute.isEmpty &&
+    !defn.filters.exists(_.getClass == classOf[GlobalRouteRateLimit]) &&
+    !defn.filters.exists(_.getClass == classOf[ClientSpecificRouteRateLimit]) &&
+    route.metadata.name.endsWith("-users-all")
+  }
+
+  def isCatchAllRoute(route: IngressDefinition): Boolean = {
+    route.metadata.routeDefinition.customRoute.exists { customRoute =>
+      NEL.of(Status(404), DefaultRejectMsg, Shunt).forall(customRoute.filters.toList.contains)
+    }
+  }
+
+  def isHttpRejectRoute(route: IngressDefinition): Boolean = {
+    route.metadata.routeDefinition.customRoute.exists { customRoute =>
+      NEL.of(Status(400), HttpRejectMsg, Shunt).forall(customRoute.filters.toList.contains)
+    }
+  }
+
+  def isServiceSpecificRoute(route: IngressDefinition): Boolean = {
+    route.metadata.routeDefinition.predicates.exists(_.getClass == classOf[ClientMatch])
+  }
+
+  def isTargettedRateLimitRoute(route: IngressDefinition): Boolean = {
+    route.metadata.routeDefinition.filters.exists(_.getClass == classOf[ClientSpecificRouteRateLimit])
+  }
+
+  def isGlobalRateLimitRoute(route: IngressDefinition): Boolean = {
+    route.metadata.routeDefinition.filters.exists(_.getClass == classOf[GlobalRouteRateLimit])
+  }
+
+  def isWhitelistRejectRoute(route: IngressDefinition): Boolean = {
+    route.metadata.name.endsWith("-non-whitelisted")
+  }
+
+  def isStandardServiceRoute(route: IngressDefinition): Boolean = {
+    val defn = route.metadata.routeDefinition
+    defn.customRoute.isEmpty &&
+    !defn.filters.exists(_.getClass == classOf[GlobalRouteRateLimit]) &&
+    !defn.filters.exists(_.getClass == classOf[ClientSpecificRouteRateLimit]) &&
+    route.metadata.name.endsWith("-all") &&
+    !isWhitelistedUserRoute(route)
+  }
+}


### PR DESCRIPTION
  * Document Weighting of routes
  * Update all generated routes to have large drivide weights associated with them
  * Add tests to check for precedence in the case ofdynamic predicates added in Skipper.

Signed-off-by: bmooney <brian.mooney@zalando.ie>