### PR TITLE
Allow string or number in stackset ingress

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val commonSettings = Seq(
 )
 
 fork in IntegrationTest := true
-envVars in IntegrationTest := Map("SKUBER_URL" -> "http://localhost:8001")
 
 test := Seq(
   (test in Test).value,

--- a/deploy/test-app/apply/stackset.yaml
+++ b/deploy/test-app/apply/stackset.yaml
@@ -25,3 +25,6 @@ spec:
                   memory: 100Mi
                 limits:
                   memory: 100Mi
+      stackLifecycle:
+        limit: 5
+        scaledownTTLSeconds: 300

--- a/deploy/test-app/apply/stackset.yaml
+++ b/deploy/test-app/apply/stackset.yaml
@@ -5,6 +5,9 @@ metadata:
     application: gw-test-stack
   name: gw-test-stack
 spec:
+  stackLifecycle:
+    limit: 2
+    scaledownTTLSeconds: 300
   externalIngress:
     backendPort: 5678
   stackTemplate:
@@ -25,6 +28,3 @@ spec:
                   memory: 100Mi
                 limits:
                   memory: 100Mi
-      stackLifecycle:
-        limit: 5
-        scaledownTTLSeconds: 300

--- a/src/it/resources/synch/sampleSynchRequestWithStacksetNamedPort.json
+++ b/src/it/resources/synch/sampleSynchRequestWithStacksetNamedPort.json
@@ -1,0 +1,95 @@
+{
+  "controller": {
+    "metadata": {
+      "name": "fabric-gateway-operator",
+      "selfLink": "/apis/metacontroller.k8s.io/v1alpha1/compositecontrollers/fabric-gateway-operator",
+      "uid": "f8e794cb-a7b2-11e8-8a04-0aa4eeea574e",
+      "resourceVersion": "100656107",
+      "generation": 1,
+      "creationTimestamp": "2018-08-24T15:32:55Z",
+      "labels": {
+        "deployment-id": "d-4zhsdviy5w6yvbvwq4o8q6e3x"
+      },
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"metacontroller.k8s.io/v1alpha1\",\"kind\":\"CompositeController\",\"metadata\":{\"annotations\":{},\"labels\":{\"deployment-id\":\"d-4zhsdviy5w6yvbvwq4o8q6e3x\"},\"name\":\"fabric-gateway-operator\",\"namespace\":\"\"},\"spec\":{\"childResources\":[{\"apiVersion\":\"extensions/v1beta1\",\"resource\":\"ingresses\",\"updateStrategy\":{\"method\":\"Recreate\"}}],\"generateSelector\":true,\"hooks\":{\"sync\":{\"webhook\":{\"url\":\"http://fabric-gateway-operator/synch\"}}},\"parentResource\":{\"apiVersion\":\"zalando.org/v1\",\"resource\":\"fabricgateways\"}}}\n",
+        "zalando.org/backend-weights": {
+          "my-app-1": 80,
+          "my-app-2": 20
+        }
+      }
+    },
+    "spec": {
+      "parentResource": {
+        "apiVersion": "zalando.org/v1",
+        "resource": "fabricgateways"
+      },
+      "childResources": [
+        {
+          "apiVersion": "extensions/v1beta1",
+          "resource": "ingresses",
+          "updateStrategy": {
+            "method": "Recreate",
+            "statusChecks": {}
+          }
+        }
+      ],
+      "hooks": {
+        "sync": {
+          "webhook": {
+            "url": "http://fabric-gateway-operator/synch"
+          }
+        }
+      },
+      "generateSelector": true
+    },
+    "status": {}
+  },
+  "parent": {
+    "apiVersion": "zalando.org/v1",
+    "kind": "FabricGateway",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"zalando.org/v1\",\"kind\":\"FabricGateway\",\"metadata\":{\"annotations\":{},\"name\":\"my-app-gateway\",\"namespace\":\"default\"},\"spec\":{\"paths\":{\"/api/resource\":{\"post\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimits\":{\"default-rate\":10,\"period\":\"minute\",\"target\":{\"spp_service_name\":50}}}},\"/api/resource/*\":{\"get\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.read\"]}},\"patch\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimit\":{\"default-rate\":10}},\"put\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.write\"]},\"x-fabric-ratelimit\":{\"default-rate\":10}}},\"/events\":{\"post\":{\"security\":{\"x-fabric-privileges\":[\"uid\",\"spp-application.read\"]}}}},\"service\":{\"host\":\"my-app.smart-product-platform-test.zalan.do\",\"serviceName\":\"my-app-service-name\"},\"whitelist\":[\"jblogs\"]}}\n"
+      },
+      "clusterName": "",
+      "creationTimestamp": "2018-09-07T07:57:57Z",
+      "generation": 1,
+      "name": "my-app-gateway",
+      "namespace": "default",
+      "resourceVersion": "103077506",
+      "selfLink": "/apis/zalando.org/v1/namespaces/default/fabricgateways/my-app-gateway",
+      "uid": "bbd2e8ce-b273-11e8-91ce-0ae88fb011ae"
+    },
+    "spec": {
+      "paths": {
+        "/api/resource": {
+          "post": {
+            "x-fabric-privileges": [
+              "uid",
+              "spp-application.write"
+            ],
+            "x-fabric-ratelimits": {
+              "default-rate": 10,
+              "period": "minute",
+              "target": {
+                "spp_service_name": 50
+              }
+            }
+          }
+        }
+      },
+      "x-external-service-provider": {
+        "stackSetName": "my-test-stackset-with-named-port",
+        "hosts": [
+          "my-app.smart-product-platform-test.zalan.do"
+        ]
+      },
+      "x-fabric-admins": [
+        "jblogs"
+      ]
+    }
+  },
+  "children": {
+    "Ingress.extensions/v1beta1": {}
+  }
+}

--- a/src/it/resources/wiremock/__files/stack-set-with-named-port.json
+++ b/src/it/resources/wiremock/__files/stack-set-with-named-port.json
@@ -1,0 +1,84 @@
+{
+  "apiVersion": "zalando.org/v1",
+  "kind": "StackSet",
+  "metadata": {
+    "annotations": {
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"zalando.org/v1\",\"kind\":\"StackSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"application\":\"my-test-stackset-with-no-status\"},\"name\":\"my-test-stackset-with-no-status\",\"namespace\":\"default\"},\"spec\":{\"ingress\":{\"backendPort\":\"ingress\",\"hosts\":[\"my-test-stackset-with-no-status.smart-product-platform-test.zalan.do\"]},\"stackLifecycle\":{\"limit\":5,\"scaledownTTLSeconds\":300},\"stackTemplate\":{\"spec\":{\"podTemplate\":{\"spec\":{\"containers\":[{\"env\":[{\"name\":\"COLOR\",\"value\":\"blue\"}],\"image\":\"pierone.stups.zalan.do/teapot/training-example:latest\",\"name\":\"my-test-stackset-with-no-status\",\"ports\":[{\"containerPort\":8080,\"name\":\"ingress\"}],\"readinessProbe\":{\"httpGet\":{\"path\":\"/healthz\",\"port\":8080}},\"resources\":{\"limits\":{\"cpu\":\"10m\",\"memory\":\"10Mi\"},\"requests\":{\"cpu\":\"10m\",\"memory\":\"10Mi\"}}}]}},\"replicas\":1,\"version\":\"master-2\"}}}}\n"
+    },
+    "creationTimestamp": "2019-07-19T13:59:25Z",
+    "generation": 5,
+    "labels": {
+      "application": "my-test-stackset-with-no-status"
+    },
+    "name": "my-test-stackset-with-named-port",
+    "namespace": "default",
+    "resourceVersion": "348406460",
+    "selfLink": "/apis/zalando.org/v1/namespaces/default/stacksets/my-test-stackset-with-no-status",
+    "uid": "6ad211ef-aa2d-11e9-bff4-0aa6f2255a6a"
+  },
+  "spec": {
+    "externalIngress": {
+      "backendPort": "named-port"
+    },
+    "stackLifecycle": {
+      "limit": 5,
+      "scaledownTTLSeconds": 300
+    },
+    "stackTemplate": {
+      "spec": {
+        "podTemplate": {
+          "spec": {
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "COLOR",
+                    "value": "blue"
+                  }
+                ],
+                "image": "pierone.stups.zalan.do/teapot/training-example:latest",
+                "name": "my-test-stackset-with-named-port",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "name": "ingress"
+                  }
+                ],
+                "readinessProbe": {
+                  "httpGet": {
+                    "path": "/healthz",
+                    "port": 8080
+                  }
+                },
+                "resources": {
+                  "limits": {
+                    "cpu": "10m",
+                    "memory": "30Mi"
+                  },
+                  "requests": {
+                    "cpu": "10m",
+                    "memory": "30Mi"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "replicas": 1,
+        "version": "master-2"
+      }
+    }
+  },
+  "status": {
+    "observedStackVersion": "master-2",
+    "readyStacks": 2,
+    "stacks": 2,
+    "stacksWithTraffic": 2,
+    "traffic": [{
+      "serviceName": "has-named-port",
+      "servicePort": "named-port",
+      "stackName": "has-named-port-version-1",
+      "weight": 100
+    }]
+  }
+}

--- a/src/it/resources/wiremock/mappings/validStacksetQueryWithNamedPort.json
+++ b/src/it/resources/wiremock/mappings/validStacksetQueryWithNamedPort.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "url": "/apis/zalando.org/v1/namespaces/default/stacksets/my-test-stackset-with-named-port"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "stack-set-with-named-port.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}

--- a/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
+++ b/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
@@ -13,6 +13,7 @@ import ie.zalando.fabric.gateway.web.{GatewayWebhookRoutes, OperationalRoutes}
 import io.circe.Json
 import org.mockito.scalatest.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import skuber.api.Configuration
 import skuber.api.client.KubernetesClient
 import skuber.k8sInit
 
@@ -29,18 +30,12 @@ class ApiValidationSpec
     with BeforeAndAfterEach
     with BeforeAndAfterAll {
 
-  val kubernetesClient: KubernetesClient = k8sInit
+  val kubernetesClient: KubernetesClient = k8sInit(Configuration.useProxyAt("http://localhost:8001"))
   val stackSetOperations                 = new StackSetOperations(kubernetesClient)
   val ingressDerivationLogic             = new IngressDerivationChain(stackSetOperations, None)
   val ingressTransitions                 = new ZeroDowntimeIngressTransitions(ingressDerivationLogic)
 
   var wireMockServer: WireMockServer = _
-
-  override def beforeAll(): Unit = {
-    if (System.getenv("SKUBER_URL")  == null) {
-      throw new IllegalArgumentException("ApiValidationSpec requires env var 'SKUBER_URL' to be set to 'http://localhost:8001'")
-    }
-  }
 
   override def beforeEach(): Unit = {
     wireMockServer = new WireMockServer(

--- a/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
+++ b/src/it/scala/ie/zalando/fabric/gateway/ApiValidationSpec.scala
@@ -12,7 +12,7 @@ import ie.zalando.fabric.gateway.service.{IngressDerivationChain, StackSetOperat
 import ie.zalando.fabric.gateway.web.{GatewayWebhookRoutes, OperationalRoutes}
 import io.circe.Json
 import org.mockito.scalatest.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import skuber.api.Configuration
 import skuber.api.client.KubernetesClient
 import skuber.k8sInit
@@ -27,10 +27,9 @@ class ApiValidationSpec
     with OperationalRoutes
     with GatewayWebhookRoutes
     with TestJsonModels
-    with BeforeAndAfterEach
-    with BeforeAndAfterAll {
-
-  val kubernetesClient: KubernetesClient = k8sInit(Configuration.useProxyAt("http://localhost:8001"))
+    with BeforeAndAfterEach {
+  val wiremockPort = 8001
+  val kubernetesClient: KubernetesClient = k8sInit(Configuration.useProxyAt(s"http://localhost:$wiremockPort"))
   val stackSetOperations                 = new StackSetOperations(kubernetesClient)
   val ingressDerivationLogic             = new IngressDerivationChain(stackSetOperations, None)
   val ingressTransitions                 = new ZeroDowntimeIngressTransitions(ingressDerivationLogic)
@@ -41,7 +40,7 @@ class ApiValidationSpec
     wireMockServer = new WireMockServer(
       WireMockConfiguration
         .wireMockConfig()
-        .port(8001)
+        .port(wiremockPort)
         .withRootDirectory("src/it/resources/wiremock")
     )
     wireMockServer.start()

--- a/src/it/scala/ie/zalando/fabric/gateway/TestUtils.scala
+++ b/src/it/scala/ie/zalando/fabric/gateway/TestUtils.scala
@@ -68,6 +68,10 @@ object TestUtils {
       def payload: String =
         Source.fromResource("synch/sampleSynchRequestWithStacksetManagingServicesButNoTrafficStatus.json").mkString
     }
+    case object ValidSynchRequestWithStackSetManagingServicesAndNamedPort extends ResourcePayload {
+      def payload: String =
+        Source.fromResource("synch/sampleSynchRequestWithStacksetNamedPort.json").mkString
+    }
     case object ValidSynchRequestWithCorsEnabled extends ResourcePayload {
       def payload: String =
         Source.fromResource("synch/sampleSynchRequestWithCors.json").mkString

--- a/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/service/StackSetOperations.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 case class StackSetIdentifier(name: String, namespace: String)
-case class StackSetIngress(backendPort: Int)
+case class StackSetIngress(backendPort: K8sServicePortIdentifier)
 case class StackSetSpec(externalIngress: Option[StackSetIngress])
 case class StackDefinedService(serviceName: String, servicePort: K8sServicePortIdentifier, weight: Double)
 case class StackSetStatus(readyStacks: Int, stacks: Int, stacksWithTraffic: Int, traffic: Option[Seq[StackDefinedService]])


### PR DESCRIPTION
- Allow backendPort to be a string
- Add integration test
- Remove the need for SKUBER_URL env var in integration tests
- Fix e2e test stackset definition, since there were some breaking changes