### PR TITLE
MID-2487: Multi Method Support

### DIFF
--- a/deploy/operator/apply/01_FabricGatewayCRD.yaml
+++ b/deploy/operator/apply/01_FabricGatewayCRD.yaml
@@ -122,8 +122,11 @@ spec:
               additionalProperties:
                 type: object
                 minProperties: 1
-                description: Each key represents a supported HTTP verb on the parent path
-                example: get, head, put, post, patch, delete
+                description: |
+                  Each key represents a supported HTTP verb on the parent path. It is possible to group methods which
+                  have the same configuration by using the pipe syntax e.g. `get|post`. It's invalid to have a method
+                  appear twice.
+                example: get, head, put, post, patch, delete, get|post
                 additionalProperties:
                   type: object
                   properties:


### PR DESCRIPTION
  * Document multi method support in CRD

Signed-off-by: bmooney <brian.mooney@zalando.ie>

 - [x] Document multi method support in Schema
 - [ ] Add admission hook check to ensure that methods aren't used standalone and in multi method key
 - [ ] Add support for multi methods to map to [Skipper methods preciate](https://opensource.zalando.com/skipper/reference/predicates/#methods)
 - [ ] Document new multi method support in Fabric docs