### PR TITLE
Use problem json response for rate limits

### DIFF
--- a/src/e2e/scala/ie/zalando/fabric/gateway/model/Model.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/model/Model.scala
@@ -1,0 +1,5 @@
+package ie.zalando.fabric.gateway.model
+
+object Model {
+  case class SimpleResponse(status: Int, body: String, headers: Map[String, String])
+}

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/RateLimitingSpec.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/RateLimitingSpec.scala
@@ -1,6 +1,7 @@
 package ie.zalando.fabric.gateway.spec
 
-import com.softwaremill.sttp._
+import com.softwaremill.sttp.StatusCodes.{Ok, TooManyRequests}
+import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, sttp}
 import ie.zalando.fabric.gateway.{LoggingSttpBackend, TestConstants}
 import org.scalatest._
 
@@ -9,8 +10,6 @@ class RateLimitingSpec extends FunSpec with Matchers {
   implicit val backend = new LoggingSttpBackend[Id, Nothing](HttpURLConnectionBackend())
 
   private val RequestBlitzSize = 50
-  private val HttpOk           = 200
-  private val RateLimited      = 429
 
   describe("Fabric Gateway Rate Limiting") {
 
@@ -19,11 +18,13 @@ class RateLimitingSpec extends FunSpec with Matchers {
         .get(TestConstants.RateLimitedForAll())
         .header("Authorization", s"Bearer ${TestConstants.ValidNonWhitelistedToken}")
 
-      val results = runReqs(RequestBlitzSize).filterNot(_ == HttpOk)
+      val results = runReqs(RequestBlitzSize).filterNot(_.status == Ok)
 
       results.nonEmpty shouldBe true
-      results.forall(_ == RateLimited) shouldBe true
       results.size should not be RequestBlitzSize
+      results.map(_.status) should contain only TooManyRequests
+      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
+      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     // Seems to be a skipper bug where rate limiting is not restricted to the route
@@ -32,11 +33,13 @@ class RateLimitingSpec extends FunSpec with Matchers {
         .get(TestConstants.RateLimitedForMe())
         .header("Authorization", s"Bearer ${TestConstants.ValidNonWhitelistedToken}")
 
-      val results = runReqs(RequestBlitzSize).filterNot(_ == HttpOk)
+      val results = runReqs(RequestBlitzSize).filterNot(_.status == Ok)
 
       results.nonEmpty shouldBe true
-      results.forall(_ == RateLimited) shouldBe true
       results.size should not be RequestBlitzSize
+      results.map(_.status) should contain only TooManyRequests
+      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
+      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     it("should not apply service specific rate limits if the service id does not match") {
@@ -44,7 +47,7 @@ class RateLimitingSpec extends FunSpec with Matchers {
         .get(TestConstants.RateLimitedForOther())
         .header("Authorization", s"Bearer ${TestConstants.ValidNonWhitelistedToken}")
 
-      val results = runReqs(RequestBlitzSize).dropWhile(_ == HttpOk)
+      val results = runReqs(RequestBlitzSize).dropWhile(_.status == Ok)
       results shouldBe empty
     }
   }

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/RateLimitingSpec.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/RateLimitingSpec.scala
@@ -23,8 +23,8 @@ class RateLimitingSpec extends FunSpec with Matchers {
       results.nonEmpty shouldBe true
       results.size should not be RequestBlitzSize
       results.map(_.status) should contain only TooManyRequests
-      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
-      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
+      all(results.map(_.body)) should include("\"title\": \"Rate limit exceeded\"")
+      all(results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     // Seems to be a skipper bug where rate limiting is not restricted to the route
@@ -38,8 +38,8 @@ class RateLimitingSpec extends FunSpec with Matchers {
       results.nonEmpty shouldBe true
       results.size should not be RequestBlitzSize
       results.map(_.status) should contain only TooManyRequests
-      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
-      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
+      all(results.map(_.body)) should include("\"title\": \"Rate limit exceeded\"")
+      all(results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     it("should not apply service specific rate limits if the service id does not match") {

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/StaticRouteSpec.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/StaticRouteSpec.scala
@@ -29,8 +29,8 @@ class StaticRouteSpec extends FunSpec with Matchers {
 
       results.nonEmpty shouldBe true
       results.map(_.status) should contain only TooManyRequests
-      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
-      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
+      all(results.map(_.body)) should include("\"title\": \"Rate limit exceeded\"")
+      all(results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     it("should reject requests with no token with a 401") {

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/StaticRouteSpec.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/StaticRouteSpec.scala
@@ -1,5 +1,6 @@
 package ie.zalando.fabric.gateway.spec
 
+import com.softwaremill.sttp.StatusCodes.{Forbidden, ServiceUnavailable, TooManyRequests, Unauthorized}
 import com.softwaremill.sttp.{HttpURLConnectionBackend, Id, RequestT, sttp}
 import ie.zalando.fabric.gateway.{LoggingSttpBackend, TestConstants}
 import org.scalatest.{FunSpec, Matchers}
@@ -13,7 +14,7 @@ class StaticRouteSpec extends FunSpec with Matchers {
         .header("Authorization", s"Bearer ${TestConstants.ValidNonWhitelistedToken}")
         .send()
 
-      resp.code shouldBe 503
+      resp.code shouldBe ServiceUnavailable
       resp.contentType shouldBe Some("application/problem+json")
       resp.header("X-Custom-Header") shouldBe Some("Some value")
       resp.body shouldBe Left("""{"title": "Service down for maintenance", "status": 503}""")
@@ -24,16 +25,18 @@ class StaticRouteSpec extends FunSpec with Matchers {
         .get(TestConstants.TestAppStaticRoute())
         .header("Authorization", s"Bearer ${TestConstants.ValidWhiteListToken}")
 
-      val results = runReqs(5).filterNot(_ == 503)
+      val results = runReqs(5).filterNot(_.status == ServiceUnavailable)
 
       results.nonEmpty shouldBe true
-      results.forall(_ == 429) shouldBe true
+      results.map(_.status) should contain only TooManyRequests
+      all (results.map(_.body)) should include ("\"title\": \"Rate limit exceeded\"")
+      all (results.map(r => getHeader("Content-Type", r.headers))) shouldBe Some("application/problem+json")
     }
 
     it("should reject requests with no token with a 401") {
       val resp = sttp.get(TestConstants.TestAppStaticRoute()).send()
 
-      resp.code shouldBe 401
+      resp.code shouldBe Unauthorized
     }
 
     it("should reject requests which don't have the required scopes") {
@@ -42,7 +45,7 @@ class StaticRouteSpec extends FunSpec with Matchers {
         .header("Authorization", s"Bearer ${TestConstants.ValidResourceWhiteListToken}")
         .send()
 
-      resp.code shouldBe 403
+      resp.code shouldBe Forbidden
     }
   }
 }

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/package.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/package.scala
@@ -1,14 +1,24 @@
 package ie.zalando.fabric.gateway
 
 import com.softwaremill.sttp.{Id, RequestT}
+import ie.zalando.fabric.gateway.model.Model.SimpleResponse
 
 import scala.annotation.tailrec
 
 package object spec {
   @tailrec
-  final def runReqs(i: Int, results: List[Int] = Nil)(implicit req: RequestT[Id, String, Nothing],
-                                                      backend: LoggingSttpBackend[Id, Nothing]): List[Int] = i match {
-    case 0 => results
-    case _ => runReqs(i - 1, req.send().code :: results)
-  }
+  final def runReqs(i: Int, results: List[SimpleResponse] = Nil)(implicit req: RequestT[Id, String, Nothing],
+                                                                 backend: LoggingSttpBackend[Id, Nothing]): List[SimpleResponse] =
+    i match {
+      case 0 => results
+      case _ =>
+        val res = req.send()
+        val body = res.rawErrorBody match {
+          case Left(v) => new String(v)
+          case Right(v) => v
+        }
+        runReqs(i - 1, SimpleResponse(res.code, body, res.headers.toMap) :: results)
+    }
+
+  def getHeader(headerKey: String, headers: Map[String, String]): Option[String] = headers.find(_._1.equalsIgnoreCase(headerKey)).map(_._2)
 }

--- a/src/e2e/scala/ie/zalando/fabric/gateway/spec/package.scala
+++ b/src/e2e/scala/ie/zalando/fabric/gateway/spec/package.scala
@@ -14,11 +14,12 @@ package object spec {
       case _ =>
         val res = req.send()
         val body = res.rawErrorBody match {
-          case Left(v) => new String(v)
+          case Left(v)  => new String(v)
           case Right(v) => v
         }
         runReqs(i - 1, SimpleResponse(res.code, body, res.headers.toMap) :: results)
     }
 
-  def getHeader(headerKey: String, headers: Map[String, String]): Option[String] = headers.find(_._1.equalsIgnoreCase(headerKey)).map(_._2)
+  def getHeader(headerKey: String, headers: Map[String, String]): Option[String] =
+    headers.find(_._1.equalsIgnoreCase(headerKey)).map(_._2)
 }

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -28,7 +28,7 @@ object SynchDomain {
   object Constants {
     val PROBLEM_JSON = "application/problem+json"
     val RATE_LIMIT_RESPONSE_BODY =
-      """{"title":"Rate limit exceeded", "detail":"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.", "status":429}"""
+      """{"title": "Rate limit exceeded", "detail": "See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.", "status": 429}"""
     val RATE_LIMIT_RESPONSE: String = InlineContentIfStatus(429, RATE_LIMIT_RESPONSE_BODY, Some(PROBLEM_JSON)).skipperStringValue
   }
 

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -3,7 +3,6 @@ package ie.zalando.fabric.gateway.models
 import akka.http.scaladsl.model.Uri
 import cats.Show
 import cats.data.NonEmptyList
-import ie.zalando.fabric.gateway.models.SynchDomain.Constants.RATE_LIMIT_RESPONSE
 import ie.zalando.fabric.gateway.util.Util.escapeQuotes
 
 object SynchDomain {
@@ -29,7 +28,7 @@ object SynchDomain {
     val PROBLEM_JSON = "application/problem+json"
     val RATE_LIMIT_RESPONSE_BODY =
       """{"title": "Rate limit exceeded", "detail": "See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.", "status": 429}"""
-    val RATE_LIMIT_RESPONSE: String = InlineContentIfStatus(429, RATE_LIMIT_RESPONSE_BODY, Some(PROBLEM_JSON)).skipperStringValue
+    val RATE_LIMIT_RESPONSE: InlineContentIfStatus = InlineContentIfStatus(429, RATE_LIMIT_RESPONSE_BODY, Some(PROBLEM_JSON))
   }
 
   sealed trait SkipperPartial {
@@ -119,7 +118,7 @@ object SynchDomain {
       extends SkipperFilter {
     private val groupName = s"${gatewayName}_${DnsString.formatPath(path.path)}_${operation.verb.value}"
     val skipperStringValue: String =
-      s"""$RATE_LIMIT_RESPONSE -> clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
+      s"""clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
   }
 
   case class GlobalUsersRouteRateLimit(gatewayName: String,
@@ -131,7 +130,7 @@ object SynchDomain {
     private val groupName = s"${gatewayName}_${DnsString.formatPath(path.path)}_${operation.verb.value}_users"
 
     val skipperStringValue: String =
-      s"""$RATE_LIMIT_RESPONSE -> clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
+      s"""clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
   }
 
   case class ClientSpecificRouteRateLimit(gatewayName: String,
@@ -144,7 +143,7 @@ object SynchDomain {
     private val groupName = s"${gatewayName}_${DnsString.formatPath(path.path)}_${operation.verb.value}_${serviceMatch.svcName}"
 
     val skipperStringValue: String =
-      s"""$RATE_LIMIT_RESPONSE -> clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
+      s"""clusterClientRatelimit("$groupName", $allowedRequests, "1${period.skipperRepresentation}", "Authorization")"""
   }
 
   case class EnableAccessLog(httpCodePrefixes: List[Int] = List(4, 5)) extends SkipperFilter {

--- a/src/main/scala/ie/zalando/fabric/gateway/util/Util.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/util/Util.scala
@@ -1,0 +1,10 @@
+package ie.zalando.fabric.gateway.util
+
+import scala.util.matching.Regex
+
+object Util {
+  val UNESCAPED_QUOTATION_MARK_RE: Regex = "(?<!\\\\)(\")".r
+  val ESCAPED_QUOTATION_MARK             = "\\\\\""
+
+  def escapeQuotes(str: String) = UNESCAPED_QUOTATION_MARK_RE.replaceAllIn(str, ESCAPED_QUOTATION_MARK)
+}

--- a/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/IngressDerivationChainSpec.scala
@@ -480,7 +480,7 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
     svcRestrictedLimits shouldBe Set("a")
   }
 
-  "Rate limit Routes" should "all have inlineContentIfStatus to ensure they reutnr a json response" in {
+  "Rate limit Routes" should "all have inlineContentIfStatus to ensure they return a json response" in {
     val gatewayPaths: GatewayPaths = Map(
       PathMatch("/api/resource") -> PathConfig(
         Map(
@@ -515,6 +515,8 @@ class IngressDerivationChainSpec extends FlatSpec with MockitoSugar with Matcher
 
     rateLimitRoutes should not be empty
     all(rateLimitRouteFilters) should contain(RATE_LIMIT_RESPONSE)
+    // Filters are evaluated in reverse order for the response and last one wins.
+    // If clusterClientRatelimit is before inlineContentIfStatus here, then the clusterClientRatelimit filter will set the response body and content type.
     rateLimitRouteFilters.foreach { filters =>
       filters.lastIndexOf(RATE_LIMIT_RESPONSE) should be < filters.indexWhere(
         _.skipperStringValue().contains("clusterClientRatelimit"))

--- a/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
@@ -36,30 +36,29 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
       (NEL.of(FlowId), """flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("a", "b"))), """oauthTokeninfoAllScope("a", "b")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 25, PerMinute)),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
+       """clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour)),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
+       """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour), FlowId),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 25, PerMinute)),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
+       """clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour)),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
+       """clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour),
               FlowId),
-       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute)),
-       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
+       """oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute),
               FlowId),
-       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
+       """oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
     )
 
     forAll(routeDefinitions) { (input, output) =>
-      val actual = SkipperConfig.filtersInSkipperFormat(input)
-      actual shouldBe output
+      SkipperConfig.filtersInSkipperFormat(input) shouldBe output
     }
   }
 
@@ -72,7 +71,7 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
     )
 
     val expected =
-      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
+      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
     SkipperConfig.customRouteInSkipperFormat(customRoute) shouldBe expected
   }
 

--- a/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
@@ -36,25 +36,25 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
       (NEL.of(FlowId), """flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("a", "b"))), """oauthTokeninfoAllScope("a", "b")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 25, PerMinute)),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour)),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour), FlowId),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 25, PerMinute)),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour)),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour),
               FlowId),
-       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute)),
-       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
+       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute),
               FlowId),
-       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
+       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
     )
 
     forAll(routeDefinitions) { (input, output) =>
@@ -72,7 +72,7 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
     )
 
     val expected =
-      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
+      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\": \"Rate limit exceeded\", \"detail\": \"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\": 429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
     SkipperConfig.customRouteInSkipperFormat(customRoute) shouldBe expected
   }
 

--- a/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
@@ -36,29 +36,30 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
       (NEL.of(FlowId), """flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("a", "b"))), """oauthTokeninfoAllScope("a", "b")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 25, PerMinute)),
-       """clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour)),
-       """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour), FlowId),
-       """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 25, PerMinute)),
-       """clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 25, "1m", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour)),
-       """clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 15, PerHour),
               FlowId),
-       """clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
+       """inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET_svc", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute)),
-       """oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
+       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization")"""),
       (NEL.of(RequiredPrivileges(NEL.of("c")),
               GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 38, PerMinute),
               FlowId),
-       """oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
+       """oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 38, "1m", "Authorization") -> flowId("reuse")""")
     )
 
     forAll(routeDefinitions) { (input, output) =>
-      SkipperConfig.filtersInSkipperFormat(input) shouldBe output
+      val actual = SkipperConfig.filtersInSkipperFormat(input)
+      actual shouldBe output
     }
   }
 
@@ -71,7 +72,7 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
     )
 
     val expected =
-      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
+      """Path("/api/resource") && Method("DELETE") -> oauthTokeninfoAllScope("c") -> inlineContentIfStatus(429, "{\"title\":\"Rate limit exceeded\", \"detail\":\"See the x-rate-limit header for your rate limit per minute, and the retry-after header for how many seconds to wait before retrying.\", \"status\":429}", "application/problem+json") -> clusterClientRatelimit("testGW_api_GET", 15, "1m", "Authorization") -> flowId("reuse")"""
     SkipperConfig.customRouteInSkipperFormat(customRoute) shouldBe expected
   }
 

--- a/src/test/scala/ie/zalando/fabric/gateway/util/UtilSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/util/UtilSpec.scala
@@ -1,0 +1,13 @@
+package ie.zalando.fabric.gateway.util
+
+import ie.zalando.fabric.gateway.util.Util.escapeQuotes
+import org.scalatest.{FlatSpec, Matchers}
+
+class UtilSpec extends FlatSpec with Matchers {
+  "escapeQuotes" should "escape any quotation marks in the string" in {
+    val alreadyEscaped = """{\"title\": \"Service down for maintenance\", \"status\":503}"""
+    val unescaped      = """{"title": "Service down for maintenance", "status":503}"""
+    escapeQuotes(alreadyEscaped) shouldBe alreadyEscaped
+    escapeQuotes(unescaped) shouldBe alreadyEscaped
+  }
+}


### PR DESCRIPTION
Currently plaintext is returned, but we should return json according to the [api guidelines](https://opensource.zalando.com/restful-api-guidelines/#176)