### PR TITLE
Support 'second' as period for Rate Limiting

### DIFF
--- a/deploy/operator/apply/01_FabricGatewayCRD.yaml
+++ b/deploy/operator/apply/01_FabricGatewayCRD.yaml
@@ -198,6 +198,7 @@ spec:
                         period:
                           type: string
                           enum:
+                            - second
                             - minute
                             - hour
                         target:

--- a/docs-raw/site/docs/fabric-gateway-features.md
+++ b/docs-raw/site/docs/fabric-gateway-features.md
@@ -31,7 +31,7 @@ spec:
           - "spp-application.write"
         x-fabric-ratelimits:
           default-rate: 10
-          # Valid values are 'hour' and 'minute', defaults to 'minute' if omitted.
+          # Valid values are 'hour', 'minute' and 'second', defaults to 'minute' if omitted.
           period: minute
           target:
             stups_spp_service_name: 50

--- a/docs/assets/basic-install.yaml
+++ b/docs/assets/basic-install.yaml
@@ -198,6 +198,7 @@ spec:
                         period:
                           type: string
                           enum:
+                            - second
                             - minute
                             - hour
                         target:

--- a/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/models/SynchDomain.scala
@@ -243,6 +243,10 @@ object SynchDomain {
     def skipperRepresentation: String
   }
 
+  case object PerSecond extends RateLimitPeriod {
+    val skipperRepresentation = "s"
+  }
+
   case object PerMinute extends RateLimitPeriod {
     val skipperRepresentation = "m"
   }

--- a/src/main/scala/ie/zalando/fabric/gateway/web/marshalling/JsonModels.scala
+++ b/src/main/scala/ie/zalando/fabric/gateway/web/marshalling/JsonModels.scala
@@ -95,6 +95,7 @@ trait JsonModels {
         period
           .map { value =>
             value.toLowerCase match {
+              case "second" => PerSecond
               case "minute" => PerMinute
               case "hour"   => PerHour
               case _ =>

--- a/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
+++ b/src/test/scala/ie/zalando/fabric/gateway/service/SkipperConfigSpec.scala
@@ -39,6 +39,8 @@ class SkipperConfigSpec extends FlatSpec with Matchers {
        """clusterClientRatelimit("testGW_api_GET", 25, "1m", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour)),
        """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization")"""),
+      (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerSecond)),
+       """clusterClientRatelimit("testGW_api_GET", 15, "1s", "Authorization")"""),
       (NEL.of(GlobalRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), 15, PerHour), FlowId),
        """clusterClientRatelimit("testGW_api_GET", 15, "1h", "Authorization") -> flowId("reuse")"""),
       (NEL.of(ClientSpecificRouteRateLimit("testGW", PathMatch("/api"), MethodMatch(Get), ClientMatch("svc"), 25, PerMinute)),


### PR DESCRIPTION
The gateway currently supports only two periods for rate limiting: `minute` and `hour`, since rate limiting is implemented as sliding window in Skipper using a minute can be dangerous to use for high traffic applications. For example, if number of requests should be limited to 1000 requests per second, currently it needs to be set to 60,000 requests per minute, which in turns means in worst case client can make up to 60,000 requests per second.

This PR introduced `second` as supported period for rate limiting.